### PR TITLE
🧪✨ Verify fixtures directory is portable

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "preinstall": "node tasks/check-package-engines package.json",
     "lint:js": "npx eslint --ext=.js,.mjs .",
     "format:js": "npx eslint --ext=.js,.mjs --fix .",
-    "test": "npx tap --reporter=spec --no-ts --no-jsx --no-esm --no-cov --node-arg=--no-warnings --node-arg=--experimental-modules test/*.mjs",
+    "test": "npx tap --reporter=spec --no-ts --no-jsx --no-esm --no-cov --node-arg=--no-warnings --node-arg=--experimental-json-modules --node-arg=--experimental-modules test/*.mjs",
     "raid": "npx npm-run-all --sequential raid:update raid:nuke raid:reconstruct",
     "raid:update": "npx npm-check-updates -u",
     "raid:nuke": "node -e \"console.log(require('./tasks/util.js').rootNpmRequire('ansicolors').green('INFO: Nuking node_modules!\\\n'))\" && npx --ignore-existing --quiet rimraf package-lock.json node_modules && node -e \"console.log(require('./tasks/util.js').rootNpmRequire('ansicolors').red('KABOOM!\\\n'))\"",

--- a/test/fixtures/portable-test-resolver/RESOLUTIONS.json
+++ b/test/fixtures/portable-test-resolver/RESOLUTIONS.json
@@ -1,0 +1,3 @@
+{
+  "fixturesDir": "./test/fixtures/"
+}

--- a/test/test-portable-test-resolver.mjs
+++ b/test/test-portable-test-resolver.mjs
@@ -1,0 +1,28 @@
+import tap from 'tap';
+
+import { PATHS } from 'loader339/constants';
+import { fileURLToPath as fileUrl2Path } from 'url';
+import { join as pathJoin, dirname as pathDirname } from 'path';
+
+import RESOLUTIONS from './fixtures/portable-test-resolver/RESOLUTIONS.json';
+
+const __filename = fileUrl2Path(import.meta.url);
+const __dirname = pathDirname(__filename);
+
+tap.test((t) => {
+  t.ok(
+    RESOLUTIONS.fixturesDir === './test/fixtures/',
+    'RESOLUTIONS.fixturesDir should be `./test/fixtures/`'
+  );
+  t.ok(
+    pathJoin(PATHS.projectRoot, RESOLUTIONS.fixturesDir) ===
+      pathJoin(PATHS.projectRoot, './test/fixtures/'),
+    'joining `PATHS.projectRoot` and `RESOLUTIONS.fixturesDir` should resolve to the same path as joining `PATHS.projectRoot` and `./test/fixtures/`'
+  );
+  t.ok(
+    pathJoin(PATHS.projectRoot, RESOLUTIONS.fixturesDir) ===
+      pathJoin(__dirname, 'fixtures/'),
+    'joining `PATHS.projectRoot` and `RESOLUTIONS.fixturesDir` should resolve to the same path as joining `__dirname` and `fixtures/`'
+  );
+  t.done();
+});


### PR DESCRIPTION
In the issue thread about our [portable resolver test suite](https://github.com/nodejs/node/issues/49448), I stated the following...

> The only nit I have is that I think the names of these keys may need a
> little more thought. Hope to propose what I feel would be an improvement in
> the coming days.

This may be a small nit (unknown), but in order to propose any improvement, quite a bit more understanding is necessary. The only way I would be able to properly understand this well enough would be to see it working to some extent. Hopefully, this will move the needle closer in that direction.